### PR TITLE
Return default instead of None when value is not found in config file

### DIFF
--- a/door/base_command.py
+++ b/door/base_command.py
@@ -104,7 +104,7 @@ class BaseCommand:
         elif self.settings.has_option("global", name):
             source = "global"
         else:
-            return None
+            return Default
 
         # type the result
         if type == int:


### PR DESCRIPTION
get_setting(int, "max_age", 24) returns None rather than 24 if max_age is not defined in config.ini. It should return the default value of 24.