### PR TITLE
Return default instead of None when value is not found in config file

### DIFF
--- a/door/base_command.py
+++ b/door/base_command.py
@@ -104,7 +104,7 @@ class BaseCommand:
         elif self.settings.has_option("global", name):
             source = "global"
         else:
-            return None
+            return default
 
         # type the result
         if type == int:


### PR DESCRIPTION
get_setting(int, "my_value", 10) returns None instead of 10 if the value is not present in config.ini. It hsould return the specified default value of 10.