### PR TITLE
Enhanced ping command

### DIFF
--- a/door/commands/ping.py
+++ b/door/commands/ping.py
@@ -1,10 +1,23 @@
 from . import BaseCommand
 
-
 class Ping(BaseCommand):
     command = "ping"
-    description = "'ping' replies with 'pong'"
+    description = "'ping' replies with signal strength data"
     help = "This could be useful to test connectivity."
 
-    def invoke(self, msg: str, node: str) -> str:
-        return "pong"
+    def invoke(self, msg: str, node: str, packet) -> str:
+        snr = packet.get('rxSnr', None)
+        rssi = packet.get('rxRssi', None)
+        hopStart = packet.get('hopStart', None)
+        hopLimit = packet.get('hopLimit', None)
+
+        response = f"Received ping from node {node}\n"
+        if hopStart and hopLimit:
+            hops = packet['hopStart'] - packet['hopLimit']
+            response += f"Hops: {hops}\n"
+        if snr:
+            response += f"SNR: {snr}\n"
+        if rssi:
+            response += f"RSSI: {rssi}"
+
+        return response

--- a/door/manager.py
+++ b/door/manager.py
@@ -1,16 +1,15 @@
 from configparser import ConfigParser
 from inspect import getmodule
-
 from meshtastic.mesh_interface import MeshInterface
 from loguru import logger as log
 from pubsub import pub
-
 from .base_command import (
     BaseCommand,
     CommandLoadError,
     CommandRunError,
     CommandActionNotImplemented,
 )
+import inspect
 
 
 class DoorManager:
@@ -138,7 +137,11 @@ class DoorManager:
         handler = self.get_command_handler(msg.lower())
         if handler:
             try:
-                response = handler.invoke(msg, node)
+                if 'packet' in inspect.signature(handler.invoke).parameters.keys():
+                    # Expose packet data to commands like 'ping'
+                    response = handler.invoke(msg, node, packet=packet)
+                else:
+                    response = handler.invoke(msg, node)
             except CommandRunError:
                 response = f"Command to '{handler.command}' failed."
         else:


### PR DESCRIPTION
Instead of returning a simple 'pong', the 'ping' command retrieves the hop count, snr, and rssi values from the meshtastic packet and returns them to the user. This required a small change in manager.py to pass the packet object to the command handler if it expects 'packet' as an argument.