### PR TITLE
Persistent sessions

### DIFF
--- a/door/base_command.py
+++ b/door/base_command.py
@@ -3,6 +3,7 @@ from inspect import getmodule
 from collections.abc import Callable
 from configparser import ConfigParser
 from pathlib import Path
+from datetime import datetime
 
 from meshtastic.mesh_interface import MeshInterface
 
@@ -49,6 +50,9 @@ class BaseCommand:
 
     # global settings object
     settings: ConfigParser
+
+    # Persistent session state
+    session_persist: dict[str, int] = {}
 
     def load(self):
         """
@@ -119,3 +123,15 @@ class BaseCommand:
             return Path(self.settings.get(source, name, fallback=default))
         else:
             return self.settings.get(source, name, fallback=default)
+
+    def persistent_session(self, node: str, persist: bool | None = None) -> bool:
+        # Return current session state for node: state = self.persistent_session(node)
+        # Or set persistent session: self.persistent_session(node, True)
+        # Or end persistent session: self.persistent_session(node, False)
+        # Time out sessions after 15 minutes
+        if persist is not None:
+            if persist:
+                self.session_persist[node] = int(datetime.now().timestamp())
+            else:
+                self.session_persist[node] = 0
+        return int(datetime.now().timestamp()) - self.session_persist.get(node, 0) < 900


### PR DESCRIPTION
The idea is that you have a game or some other interactive command and you don't want the user to have to type the command at the beginning of each message. See PRs for tic-tac-toe and Zork as examples. This PR makes changes to the BaseCommand class to add a variable to store session state and a method that can be used to get/set the session state. It also makes changes to the door manager to remember the last command sent by each node and send subsequent messages to the previous command handler if a persistent session has been established. Sessions will time out after 15 minutes of inactivity so if somebody gets distracted in the middle of a session, when they come back an hour or day or month later, new messages will be handled normally by door manager rather than being sent to an old session they forgot about.