### PR TITLE
Fixed bug in get_setting()

### DIFF
--- a/door/base_command.py
+++ b/door/base_command.py
@@ -99,6 +99,10 @@ class BaseCommand:
         """
         module = getmodule(self).__name__
 
+        # In case command is in a subdirectory
+        if module not in self.settings.sections():
+            module = module.rsplit('.', 1)[0]
+
         # where should we get this setting from?
         source = None
         if self.settings.has_option(module, name):


### PR DESCRIPTION
If your command is a single python file like "mail.py", then the module name is "door.commands.mail" which matches the section in the config.ini file. But if you break your command into multiple files and place them in a subdirectory the module name ends up being something like "door.commands.mail.mail_command" which does not match a section in the config.ini file, so get_setting() does not return any configuration values.

If the module name does not match any of the config file sections because our command is in a subdirectory, we need to strip off the last part and try that too.